### PR TITLE
Big fixes and "disabled" property

### DIFF
--- a/birch-standards-picker.css
+++ b/birch-standards-picker.css
@@ -151,6 +151,10 @@ birch-typeahead {
     color: #333331;
     padding: 6px 10px;
   }
+
+  --birch-typeahead-input-disabled: {
+    background-color: #eee;
+  }
 }
 paper-item, paper-icon-item, paper-item-body {
   --paper-item: {

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -79,11 +79,12 @@ Example:
       </template>
     </birch-typeahead>
 
-    <div class="standard-container" hidden$='[[_hideStandardsContainer(data, standardType, i18n)]]'>
+    <div class="standard-container" hidden$='[[_hideStandardsContainer(data, standardType, i18n, hideStandardsMenu)]]'>
       <p>
         <small>[[standardsDropdownLabel]]</small>
         <button
           id="button"
+          type="button"
           class="standard-button"
           on-focusout="_handleFocusout"
           on-tap="_openStandardSelector"
@@ -221,7 +222,7 @@ Example:
           type: Object,
           value: function() { return {}; },
           observer: '_handleDataChange',
-          notifies: true
+          notify: true
         },
 
         /**
@@ -247,6 +248,11 @@ Example:
         _hideStandards: {
           type: Boolean,
           value: true
+        },
+
+        hideStandardsMenu: {
+          type: Boolean,
+          value: false
         }
       },
 
@@ -341,7 +347,7 @@ Example:
 
       _updateLabels: function(i18n, standardType) {
         this.standardsDropdownLabel = this.i18n('STANDARD_' + this.standardType.toUpperCase() + '_LABEL');
-        this.inputLabel = this.i18n('EVENT_' + this.standardType.toUpperCase() + '_LABEL');
+        this.inputLabel = this.inputLabel || this.i18n('EVENT_' + this.standardType.toUpperCase() + '_LABEL');
       },
 
       _getPlaceholder: function(type, i18n) {
@@ -604,7 +610,9 @@ Example:
         return label === i18n('NO_STANDARD_SELECTED');
       },
 
-      _hideStandardsContainer: function(data, standardType, i18n) {
+      _hideStandardsContainer: function(data, standardType, i18n, hideStandardsMenu) {
+        if(hideStandardsMenu) return true;
+
         return !data.customText || data.label === i18n('NO_STANDARD_' + standardType.toUpperCase() + '_AVAILABLE');
       },
 

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -42,9 +42,10 @@ Example:
       highlight-first-item
       follow-tabindex-after-tab-select
       loading="[[loading]]"
+      disabled="[[disabled]]"
       debounce-input-duration="200"
       value="{{searchTerm::birch-typeahead:input}}"
-      placeholder="[[_getPlaceholder(standardType, i18n)]]"
+      placeholder="[[_getPlaceholder(standardType, i18n, disabled)]]"
       options="[[_typeaheadOptions]]"
       on-birch-typeahead:input='_handleInput'
       on-birch-typeahead:cancel='_handleCancel'
@@ -225,6 +226,14 @@ Example:
           notify: true
         },
 
+        /** Whether the typeahead input should be disabled or not.
+         * @type {Boolean}
+         */
+        disabled: {
+          type: Boolean,
+          value: false
+        },
+
         /**
          * Whether a network call is pending and spinners should show
          *
@@ -350,9 +359,10 @@ Example:
         this.inputLabel = this.inputLabel || this.i18n('EVENT_' + this.standardType.toUpperCase() + '_LABEL');
       },
 
-      _getPlaceholder: function(type, i18n) {
+      _getPlaceholder: function(type, i18n, disabled) {
+        if (disabled) return '';
         var string = type.toUpperCase() + '_PLACEHOLDER';
-        return this.i18n(string);
+        return i18n(string);
       },
 
       _handleInput: function(e, onlySetStandardOptions) {

--- a/test/birch-standards-picker-test.html
+++ b/test/birch-standards-picker-test.html
@@ -36,7 +36,7 @@
         before(function() {
           server = sinon.fakeServer.create();
         });
-          
+
         beforeEach(function() {
           myEl = fixture('birch-standards-picker-fixture');
           myEl.reset();
@@ -145,7 +145,7 @@
           })
         });
 
-        describe.only('_handleSelect', function() {
+        describe('_handleSelect', function() {
           var e = {
             detail : {
               selection : {
@@ -171,7 +171,7 @@
           })
         });
 
-        describe.only('_handleCancel', function() {
+        describe('_handleCancel', function() {
           it('should set no standard selected when we do not have a standard already', function() {
             myEl._standardOptions = [1,2,3];
             myEl.searchTerm = 'not blank';
@@ -417,6 +417,30 @@
             expect(a === b).to.be.false;
             expect(a.hi).to.equal(b.hi);
           })
+        });
+
+        describe('_getPlaceholder', function() {
+          var type,
+              disabled,
+              i18n;
+
+          function i18n(key){
+            return key;
+          }
+
+          beforeEach(function(){
+            type = "DATE";
+            disabled = false;
+          });
+
+          it('should return an empty string if disabled is true', function(){
+            disabled = true;
+            expect(myEl._getPlaceholder(type, i18n, disabled)).to.equal("");
+          });
+
+          it('should return an i18n translated string (mocked to return key)', function(){
+            expect(myEl._getPlaceholder(type, i18n, disabled)).to.equal("DATE_PLACEHOLDER");
+          });
         });
 
       });


### PR DESCRIPTION
There were some bug fixes that needed to be made to get this to work in our app like `notifies: true` should be `notify: true`. I believe @tylergraf also added in functionality to hide the standards menu when needed.

This also includes my changes to add a `disabled` property to pass to birch-typeahead. Placeholder  text is gated on this property. I added a couple unit tests to reflect this behavior. See https://github.com/FamilySearchElements/birch-typeahead/pull/8