### PR TITLE
Fix for enter key on birch-typeahead

### DIFF
--- a/birch-standards-picker.css
+++ b/birch-standards-picker.css
@@ -151,6 +151,10 @@ birch-typeahead {
     color: #333331;
     padding: 6px 10px;
   }
+
+  --birch-typeahead-input-disabled: {
+    background-color: #eee;
+  }
 }
 paper-item, paper-icon-item, paper-item-body {
   --paper-item: {

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -51,7 +51,7 @@ Example:
       on-birch-typeahead:cancel='_handleCancel'
       on-birch-typeahead:blur='_handleCancel'
       on-birch-typeahead:selected='_handleSelect'
-      on-keydown="_handleKeydown">
+      on-keydown="_preventFormSubmission">
       <template>
 
         <template is="dom-if" if="[[item.icon]]" restamp>
@@ -579,6 +579,13 @@ Example:
         e.model.item = this._standardOptions[this.$.optionsMenu.selected];
         this._handleChangeStandard(e);
         this._focusButton();
+      },
+
+      /** If the enter key is pressed, prevent the default action like a form submitting.
+       * @param {Object} e - The keydown event.
+       */
+      _preventFormSubmission: function(e){
+        if(e.which === 13) e.preventDefault();
       },
 
       _handleEscape: function(e) {

--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -42,9 +42,10 @@ Example:
       highlight-first-item
       follow-tabindex-after-tab-select
       loading="[[loading]]"
+      disabled="[[disabled]]"
       debounce-input-duration="200"
       value="{{searchTerm::birch-typeahead:input}}"
-      placeholder="[[_getPlaceholder(standardType, i18n)]]"
+      placeholder="[[_getPlaceholder(standardType, i18n, disabled)]]"
       options="[[_typeaheadOptions]]"
       on-birch-typeahead:input='_handleInput'
       on-birch-typeahead:cancel='_handleCancel'
@@ -225,6 +226,14 @@ Example:
           notify: true
         },
 
+        /** Whether the typeahead input should be disabled or not.
+         * @type {Boolean}
+         */
+        disabled: {
+          type: Boolean,
+          value: false
+        },
+
         /**
          * Whether a network call is pending and spinners should show
          *
@@ -350,9 +359,10 @@ Example:
         this.inputLabel = this.inputLabel || this.i18n('EVENT_' + this.standardType.toUpperCase() + '_LABEL');
       },
 
-      _getPlaceholder: function(type, i18n) {
+      _getPlaceholder: function(type, i18n, disabled) {
+        if (disabled) return '';
         var string = type.toUpperCase() + '_PLACEHOLDER';
-        return this.i18n(string);
+        return i18n(string);
       },
 
       _handleInput: function(e, onlySetStandardOptions) {

--- a/test/birch-standards-picker-test.html
+++ b/test/birch-standards-picker-test.html
@@ -396,6 +396,31 @@
           })
         });
 
+        describe('_preventFormSubmission', function() {
+          var e,
+              preventDefaultSpy;
+
+          beforeEach(function() {
+            e = { preventDefault : function(){return}, which: 13 };
+            preventDefaultSpy = sinon.spy(e, "preventDefault");
+          });
+
+          afterEach(function(){
+            preventDefaultSpy.reset();
+          });
+
+          it('should call e.preventDefault if e.which is 13 (the enter key)', function(){
+            myEl._preventFormSubmission(e);
+            expect(preventDefaultSpy.called).to.be.true;
+          });
+
+          it('should not call e.preventDefault if e.which is not 13', function(){
+            e.which = 2;
+            myEl._preventFormSubmission(e);
+            expect(preventDefaultSpy.called).to.be.false;
+          });
+        });
+
         describe('_handleEscape', function() {
           it('should hide the menu', function(){
             myEl._hideStandards = false;

--- a/test/birch-standards-picker-test.html
+++ b/test/birch-standards-picker-test.html
@@ -36,7 +36,7 @@
         before(function() {
           server = sinon.fakeServer.create();
         });
-          
+
         beforeEach(function() {
           myEl = fixture('birch-standards-picker-fixture');
           myEl.reset();
@@ -145,7 +145,7 @@
           })
         });
 
-        describe.only('_handleSelect', function() {
+        describe('_handleSelect', function() {
           var e = {
             detail : {
               selection : {
@@ -171,7 +171,7 @@
           })
         });
 
-        describe.only('_handleCancel', function() {
+        describe('_handleCancel', function() {
           it('should set no standard selected when we do not have a standard already', function() {
             myEl._standardOptions = [1,2,3];
             myEl.searchTerm = 'not blank';
@@ -417,6 +417,30 @@
             expect(a === b).to.be.false;
             expect(a.hi).to.equal(b.hi);
           })
+        });
+
+        describe('_getPlaceholder', function() {
+          var type,
+              disabled,
+              i18n;
+
+          function i18n(key){
+            return key;
+          }
+
+          beforeEach(function(){
+            type = "DATE";
+            disabled = false;
+          });
+
+          it('should return an empty string if disabled is true', function(){
+            disabled = true;
+            expect(myEl._getPlaceholder(type, i18n, disabled)).to.equal("");
+          });
+
+          it('should return an i18n translated string (mocked to return key)', function(){
+            expect(myEl._getPlaceholder(type, i18n, disabled)).to.equal("DATE_PLACEHOLDER");
+          });
         });
 
       });


### PR DESCRIPTION
When using the standards menu attached to `birch-typeahead`, the arrow keys can navigate, but if 'enter' is used, the form submits. This doesn't happen for the drop-down menu because it has the `on-keydown` listener. I added it to `birch-typeahead` and it fixed the problem.