### PR TITLE
Handle esc key on birch-typeahead

### DIFF
--- a/birch-standards-picker.html
+++ b/birch-standards-picker.html
@@ -51,7 +51,7 @@ Example:
       on-birch-typeahead:cancel='_handleCancel'
       on-birch-typeahead:blur='_handleCancel'
       on-birch-typeahead:selected='_handleSelect'
-      on-keydown="_preventFormSubmission">
+      on-keydown="_preventDefaultActions">
       <template>
 
         <template is="dom-if" if="[[item.icon]]" restamp>
@@ -582,10 +582,12 @@ Example:
       },
 
       /** If the enter key is pressed, prevent the default action like a form submitting.
+       * If the esc key is pressed, prevent other events listening for it from firing.
        * @param {Object} e - The keydown event.
        */
-      _preventFormSubmission: function(e){
+      _preventDefaultActions: function(e){
         if(e.which === 13) e.preventDefault();
+        if(e.which === 27) e.stopPropagation();
       },
 
       _handleEscape: function(e) {

--- a/test/birch-standards-picker-test.html
+++ b/test/birch-standards-picker-test.html
@@ -396,28 +396,44 @@
           })
         });
 
-        describe('_preventFormSubmission', function() {
+        describe('_preventDefaultActions', function() {
           var e,
-              preventDefaultSpy;
+              preventDefaultSpy,
+              stopPropagationSpy;
 
           beforeEach(function() {
-            e = { preventDefault : function(){return}, which: 13 };
+            e = {
+              "preventDefault": function(){return},
+              "stopPropagation": function(){return},
+              which: 13
+            };
             preventDefaultSpy = sinon.spy(e, "preventDefault");
+            stopPropagationSpy = sinon.spy(e, "stopPropagation");
           });
 
           afterEach(function(){
             preventDefaultSpy.reset();
+            stopPropagationSpy.reset();
           });
 
           it('should call e.preventDefault if e.which is 13 (the enter key)', function(){
-            myEl._preventFormSubmission(e);
+            myEl._preventDefaultActions(e);
             expect(preventDefaultSpy.called).to.be.true;
+            expect(stopPropagationSpy.called).to.be.false;
           });
 
-          it('should not call e.preventDefault if e.which is not 13', function(){
-            e.which = 2;
-            myEl._preventFormSubmission(e);
+          it('should call e.stopPropagation if e.which is 27 (the esc key)', function(){
+            e.which = 27;
+            myEl._preventDefaultActions(e);
+            expect(stopPropagationSpy.called).to.be.true;
             expect(preventDefaultSpy.called).to.be.false;
+          });
+
+          it('should not call e.preventDefault or e.stopPropagation if e.which is not 13 or 27', function(){
+            e.which = 2;
+            myEl._preventDefaultActions(e);
+            expect(preventDefaultSpy.called).to.be.false;
+            expect(stopPropagationSpy.called).to.be.false;
           });
         });
 


### PR DESCRIPTION
This is to fix a bug where hitting the esc key closes our modal instead of just the standards menu. I renamed our keydown listener and updated unit tests to match.