### PR TITLE
Replace missing semi-colons on mixins.

### DIFF
--- a/birch-standards-picker.css
+++ b/birch-standards-picker.css
@@ -150,11 +150,11 @@ birch-typeahead {
     box-sizing: border-box;
     color: #333331;
     padding: 6px 10px;
-  }
+  };
 
   --birch-typeahead-input-disabled: {
     background-color: #eee;
-  }
+  };
 }
 paper-item, paper-icon-item, paper-item-body {
   --paper-item: {


### PR DESCRIPTION
Styles break when minified if mixins don't have semi-colons. Simple fix. :)